### PR TITLE
Fix HumanVsComputer bug

### DIFF
--- a/cli/game_display.py
+++ b/cli/game_display.py
@@ -21,7 +21,7 @@ class GameDisplay:
         nested_rows: List[list] = []
         count: int = 0
         for i in range(board.size):
-            row: List[Any] = board.grid[count : count + board.size]
+            row: List[Any] = board.grid[count: count + board.size]
             count += board.size
             nested_rows.append(row)
         return nested_rows
@@ -55,7 +55,8 @@ class GameDisplay:
 
     @classmethod
     def prompt_spot(cls, available_spots):
-        cls.message = "Choose one of these spots [%s]:" % ", ".join(available_spots)
+        cls.message = "Choose one of these spots [%s]:" % ", ".join(
+            available_spots)
         print(cls.message)
 
     @classmethod
@@ -85,7 +86,7 @@ class GameDisplay:
         first_player = input()
         valid_input = ["O", "X"]
         if not first_player in valid_input:
-            return cls.get_first_player(cls)
+            return cls.get_first_player()
         else:
             return first_player
 

--- a/core/game.py
+++ b/core/game.py
@@ -1,3 +1,4 @@
+from core.player.bot_player import BotPlayer
 from core import GameState, Board, GameDisplay
 from core.player import HumanPlayer
 
@@ -42,16 +43,17 @@ class Game:
 
         while not self.game_state.finished(self.board):
             if self.current_player_symbol == self.player_one.symbol:
-                print("here in if")
                 self.handle_play(self.player_one)
             else:
-                print("here in else")
                 self.handle_play(self.player_two)
         self.end_game()
 
     def handle_play(self, player, **kwargs):
-        print(player)
-        spot = GameDisplay.get_player_spot(self.board.get_available_spots())
+        spot = None
+        if not isinstance(player, BotPlayer):
+            spot = GameDisplay.get_player_spot(
+                self.board.get_available_spots())
+
         player.play(board=self.board, spot=spot)
         GameDisplay.chosen_spot(player.symbol, spot)
         GameDisplay.show(self.board)

--- a/core/player/bot_player.py
+++ b/core/player/bot_player.py
@@ -8,7 +8,7 @@ class BotPlayer(Player):
     def __init__(self):
         super().__init__()
 
-    def play(self, board: Board) -> int:
+    def play(self, board: Board, **kwargs) -> int:
         winning_spot: int = board.get_expected_winning_spot()
         if winning_spot is not None:
             board.grid[winning_spot] = self.symbol
@@ -18,6 +18,5 @@ class BotPlayer(Player):
         return random_spot
 
     def get_random_available_spot(self, board: Board) -> int:
-        print("here in get random")
         available_spot = board.get_available_spots()
         return random.choice(available_spot)

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -20,11 +20,11 @@ class MockGameState:
 
 
 class MockGame:
-    def __init__(self, game_display=None):
+    def __init__(self, player_one, player_two, game_display=None):
         self.game_display = MockGameDisplay
         self.board = Board(size=self.game_display.get_board_size(self))
-        self.player_one = None
-        self.player_two = None
+        self.player_one = player_one
+        self.player_two = player_two
         self.current_player_symbol = None
         self.game_state = MockGameState
 
@@ -58,32 +58,16 @@ class MockGame:
         self.current_player_symbol = first_player
 
 
-class HumanVsHuman(MockGame):
-    def __init__(self):
-        super().__init__()
-        self.player_one = HumanPlayer()
-        self.player_two = HumanPlayer()
-
-
 class TestGame(unittest.TestCase):
     def setUp(self):
         self.game_display = MockGameDisplay()
-        self.game: Game = MockGame()
-        self.humanPlayer = HumanVsHuman()
+        self.game: Game = MockGame(player_one=HumanPlayer(), player_two=HumanPlayer(), game_display=self.game_display)
 
     def test_Game_has_a_board(self):
         self.assertIsInstance(self.game.board, Board)
 
-    def test_Game_has_no_player_one_when_Game_is_initiated(self):
-        self.assertIsNone(self.game.player_one)
-
-    def test_Game_has_no_player_two_when_game_is_initiated(self):
-        self.assertIsNone(self.game.player_two)
-
-        def test_Game_current_player_symbol__is_None_when_Game_is_initiated(self):
-            self.assertEqual(
-                self.game.current_player_symbol, None, "It should return None when there is no current player"
-            )
+    def test_Game_current_player_symbol__is_None_when_Game_is_initiated(self):
+        self.assertEqual(self.game.current_player_symbol, None, "It should return None when there is no current player")
 
     def test_Game_current_player_symbol_is_set_to_O(self):
         self.game.current_player_symbol = "O"

--- a/tests/test_game_display.py
+++ b/tests/test_game_display.py
@@ -1,6 +1,7 @@
 import unittest
 from cli import GameDisplay
 from core import Board
+from core.player import HumanPlayer, BotPlayer
 
 
 class MockGameDisplay:
@@ -13,16 +14,16 @@ class MockGameDisplay:
 
 
 class MockGame:
-    def __init__(self, game_display=None):
+    def __init__(self, player_one, player_two, game_display=None):
         self.game_display = MockGameDisplay
         self.board = Board(size=self.game_display.get_board_size(self))
-        self.player_one = None
-        self.player_two = None
+        self.player_one = player_one
+        self.player_two = player_two
 
 
 class TestGameDisplay(unittest.TestCase):
     def setUp(self):
-        self.game = MockGame(MockGameDisplay)
+        self.game = MockGame(player_one=HumanPlayer(), player_two=HumanPlayer(), game_display=MockGameDisplay())
         self.board = self.game.board
 
     def test_game_is_over_message(self):

--- a/tests/test_human_vs_computer.py
+++ b/tests/test_human_vs_computer.py
@@ -1,5 +1,5 @@
 import unittest
-from core import Board
+from core import Board, Game
 from core.player import HumanPlayer, BotPlayer
 
 
@@ -20,11 +20,11 @@ class MockGameState:
 
 
 class MockGame:
-    def __init__(self, game_display=None):
+    def __init__(self, player_one, player_two, game_display=None):
         self.game_display = MockGameDisplay
         self.board = Board(size=self.game_display.get_board_size(self))
-        self.player_one = None
-        self.player_two = None
+        self.player_one = player_one
+        self.player_two = player_two
         self.game_state = MockGameState
 
     def set_player_symbols(self, first_player: str) -> None:
@@ -63,20 +63,10 @@ class MockGame:
         pass
 
 
-class HumanVsComputer(MockGame):
-    def __init__(self):
-        super().__init__()
-        self.player_one = HumanPlayer()
-        self.player_two = BotPlayer()
-
-
 class TestHumanVsComputer(unittest.TestCase):
     def setUp(self):
-        self.game = HumanVsComputer()
+        self.game = MockGame(player_one=HumanPlayer(), player_two=BotPlayer(), game_display=MockGameDisplay())
         self.board = Board(size=3)
-
-    def test_HumanVsComputer_is_Game_subclass(self):
-        self.assertTrue(issubclass(HumanVsComputer, MockGame))
 
     def test_HumanVsComputer_inherits_play_method(self):
         self.assertIsNotNone(self.game.play)

--- a/tests/test_human_vs_computer_game_session.py
+++ b/tests/test_human_vs_computer_game_session.py
@@ -17,11 +17,11 @@ class MockGameDisplay:
 
 
 class MockGame:
-    def __init__(self, game_display=None):
+    def __init__(self, player_one, player_two, game_display=None):
         self.game_display = MockGameDisplay
         self.board = Board(size=self.game_display.get_board_size(self))
-        self.player_one = None
-        self.player_two = None
+        self.player_one = player_one
+        self.player_two = player_two
 
     def set_player_symbols(self, first_player: str) -> None:
         if first_player == "X":
@@ -54,11 +54,11 @@ class HumanVsHuman(MockGame):
         self.player_two = HumanPlayer()
 
 
-class HumanVsComputer(MockGame):
-    def __init__(self):
-        super().__init__()
-        self.player_one = HumanPlayer()
-        self.player_two = BotPlayer()
+# class HumanVsComputer(MockGame):
+#     def __init__(self):
+#         super().__init__()
+#         self.player_one = HumanPlayer()
+#         self.player_two = BotPlayer()
 
 
 class TestHumanVsComputerGameSession(unittest.TestCase):
@@ -66,44 +66,35 @@ class TestHumanVsComputerGameSession(unittest.TestCase):
 
         self.game_display = MockGameDisplay()
         self.game_session: GameSession = GameSession(self.game_display)
-        self.game: MockGame = MockGame()
-        self.human_vs_computer = HumanVsComputer()
+        self.game = Game(player_one=HumanPlayer(), player_two=BotPlayer(), game_display=self.game_display)
 
     def test_when_HumanVsComputer_set_player_symbol_to_O_then_player_one_symbol_should_be_O(self):
-        self.human_vs_computer.set_player_symbols("O")
-        self.assertEqual(
-            self.human_vs_computer.player_one.symbol, "O", "If the first player is O, player one symbol should be O"
-        )
-        self.assertEqual(
-            self.human_vs_computer.player_two.symbol, "X", "If the first player is X, player one symbol should be X"
-        )
+        self.game.set_player_symbols("O")
+        self.assertEqual(self.game.player_one.symbol, "O", "If the first player is O, player one symbol should be O")
+        self.assertEqual(self.game.player_two.symbol, "X", "If the first player is X, player one symbol should be X")
 
     def test_when_HumanVsComputer_set_player_symbol_to_X_then_player_one_symbol_should_be_X(self):
-        self.human_vs_computer.set_player_symbols("X")
-        self.assertEqual(
-            self.human_vs_computer.player_one.symbol, "X", "If the first player is X, player one symbol should be X"
-        )
-        self.assertEqual(
-            self.human_vs_computer.player_two.symbol, "O", "If the first player is O, player one symbol should be O"
-        )
+        self.game.set_player_symbols("X")
+        self.assertEqual(self.game.player_one.symbol, "X", "If the first player is X, player one symbol should be X")
+        self.assertEqual(self.game.player_two.symbol, "O", "If the first player is O, player one symbol should be O")
 
     def test_if_HumanVsComputer_set_player_symbols_first_player_X_current_player_symbol_should_be_X_when_game_starts(
         self,
     ):
         first_player = "X"
         self.game.current_player_symbol = first_player
-        self.human_vs_computer.set_player_symbols(first_player)
+        self.game.set_player_symbols(first_player)
         self.assertEqual(
             self.game.current_player_symbol, "X", "If first player is X, current player symbol should be X"
         )
 
     def test_HumanVsComputer_set_game_players_X_player_one_symbol_should_be_X(self):
-        self.human_vs_computer.set_game_players("X")
+        self.game.set_game_players("X")
 
-        self.assertEqual("X", self.human_vs_computer.player_one.symbol, "Incorrect symbol for first player.")
-        self.assertEqual("O", self.human_vs_computer.player_two.symbol, "Incorrect symbol for second player.")
+        self.assertEqual("X", self.game.player_one.symbol, "Incorrect symbol for first player.")
+        self.assertEqual("O", self.game.player_two.symbol, "Incorrect symbol for second player.")
 
     def test_HumanVsComputer_set_game_players_X_current_player_symbol_X(self):
-        self.human_vs_computer.set_game_players("X")
+        self.game.set_game_players("X")
 
-        self.assertEqual("X", self.human_vs_computer.current_player_symbol, "Incorrect current player symbol.")
+        self.assertEqual("X", self.game.current_player_symbol, "Incorrect current player symbol.")

--- a/tests/test_human_vs_human_game_session.py
+++ b/tests/test_human_vs_human_game_session.py
@@ -18,11 +18,11 @@ class MockGameDisplay:
 
 
 class MockGame:
-    def __init__(self, game_display=None):
+    def __init__(self, player_one, player_two, game_display=None):
         self.game_display = MockGameDisplay
         self.board = Board(size=self.game_display.get_board_size(self))
-        self.player_one = None
-        self.player_two = None
+        self.player_one = player_one
+        self.player_two = player_two
 
     def set_player_symbols(self, first_player: str) -> None:
         if first_player == "X":
@@ -58,7 +58,7 @@ class MockGame:
 class TestHumanVsHumanGameSession(unittest.TestCase):
     def setUp(self):
         self.game_display = MockGameDisplay()
-        self.game = Game(game_display=self.game_display)
+        self.game = Game(player_one=HumanPlayer(), player_two=HumanPlayer(), game_display=self.game_display)
         self.game_session: GameSession = GameSession(self.game_display)
 
         self.human_vs_human = HumanVsHuman(game=self.game)


### PR DESCRIPTION
This PR fixes two main issues:

1) Adds `**kwargs` argument to `BotPalyer.play` method
2) Only calls `GameDisplay.get_player_spot` in `handle_play` when it's a human's turn (-- this is what was causing the game to "hang/freeze" -- the computer does not use GameDisplay/US -- just uses a random spot). 